### PR TITLE
Fix alignment issue in migrations with multiple FKs

### DIFF
--- a/EFCore.FSharp/Migrations/Design/FSharpSnapshotGenerator.fs
+++ b/EFCore.FSharp/Migrations/Design/FSharpSnapshotGenerator.fs
@@ -456,7 +456,7 @@ type FSharpSnapshotGenerator (code : ICSharpHelper) =
             |> indent
             |> this.generateForeignKeyRelation fk
             |> appendIfTrue (fk.DeleteBehavior <> DeleteBehavior.ClientSetNull) (sprintf ".OnDelete(%s)" (fk.DeleteBehavior |> code.Literal))
-            |> appendLine " |> ignore"
+            |> appendLine "|> ignore"
             |> unindent
 
     member private this.generateForeignKeys funcId (foreignKeys: IForeignKey seq) sb =
@@ -539,6 +539,7 @@ type FSharpSnapshotGenerator (code : ICSharpHelper) =
             |> appendLine(", (fun b ->")
             |> indent
             |> this.generateRelationships "b" entityType
+            |> unindent
             |> appendLine ")) |> ignore"
             |> ignore
 


### PR DESCRIPTION
When generating a migration where the model has more than 1 FK the definition of those relationships in the Model Snapshot were not being indented correctly