### PR TITLE
Wrap parameter names in backticks if they are an F# keyword

### DIFF
--- a/EFCore.FSharp/Internal/FSharpUtilities.fs
+++ b/EFCore.FSharp/Internal/FSharpUtilities.fs
@@ -200,6 +200,9 @@ module FSharpUtilities =
             "yield";
           |]
 
+    let isKeyword str =
+        _keywords |> Seq.contains str
+
     let handleMethodCallCodeFragment (sb:StringBuilder) (methodCallCodeFragment: MethodCallCodeFragment) =
         sb.Append("(").Append(methodCallCodeFragment.Method).Append(")")
 

--- a/EFCore.FSharp/Migrations/Design/FSharpMigrationOperationGenerator.fs
+++ b/EFCore.FSharp/Migrations/Design/FSharpMigrationOperationGenerator.fs
@@ -25,7 +25,7 @@ type FSharpMigrationOperationGenerator (code : ICSharpHelper) =
     let writeParameter name value sb =
         sb
             |> append ","
-            |> append name
+            |> append (if FSharpUtilities.isKeyword name then sprintf "``%s``" name else name)
             |> append " = "
             |> appendLine (value |> code.UnknownLiteral)      
 


### PR DESCRIPTION
(Closes #31)

Some migration operations have parameters with names like `type`
That's fine in C#, but `type` is an F# keyword

This checks the parameter name and wraps it in double backticks if it is a keyword